### PR TITLE
Fix - Clear Form button event clears disabled inputs

### DIFF
--- a/app/assets/javascripts/active_element/form.js
+++ b/app/assets/javascripts/active_element/form.js
@@ -31,7 +31,8 @@
         clearFormButton.addEventListener('click', (ev) => {
           ev.preventDefault();
 
-          form.querySelectorAll('.form-fields input, .form-fields select, .form-fields textarea')
+          form.querySelectorAll('.form-fields input:enabled, .form-fields select:enabled, .form-fields textarea:enabled')
+              .filter((formInput) => !formInput.readonly)
               .forEach((formInput) => formInput.value = '');
         });
       });


### PR DESCRIPTION
### Description
Currently the `'Clear Form'` button click event clears all input values regardless of the input's is disabled or readonly attributes.

This pr changes the query selector for this button's click event listener to filter out disabled or readonly inputs.

### Links for context

1. [Html attribute readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
2. [Html attribute disabled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled)
4. [enabled psuedo class](https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled)