### PR TITLE
Fix - Form#humanized_model_name is not relying on `ActiveModel#to_model`

### DIFF
--- a/lib/active_element/components/form.rb
+++ b/lib/active_element/components/form.rb
@@ -178,7 +178,11 @@ module ActiveElement
       end
 
       def humanized_model_name
-        record.class.name.titleize
+        if record.respond_to?(:to_model)
+          record.to_model.model_name.name.titleize
+        else
+          record.class.name.titleize
+        end
       end
 
       def base_options_for_select(field, field_options)


### PR DESCRIPTION
Related: [ActiveModel::Naming](https://api.rubyonrails.org/v6.1.7.6/classes/ActiveModel/Naming.html#method-i-model_name)

### Current behaviour

When I'm passing a PORO class to the form component this is the rendered submit button

```
active_element.component.form model: GeonameConfigurations::Form.new, fields: [:etc, :etc]
```

![Screenshot 2023-10-20 at 01 09 28](https://github.com/bobf/active_element/assets/32255826/fb0af1be-532c-411a-90ce-9791e81f8041)

### Expected behaviour

Rails' own `form_with` form helper can handle this situation. I followed the rails source to find how it's handled. This is the trace I've followed

1. [form_with helper](https://github.com/rails/rails/blob/56bcc0abd3c9a6b09469e9428f6eea0dd77c2294/actionview/lib/action_view/helpers/form_helper.rb#L742)
2. [polymorphic_path](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L126)
3. [polymorphic_mapping](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L170)

```rb
 def polymorphic_mapping(record)
  if record.respond_to?(:to_model)
    _routes.polymorphic_mappings[record.to_model.model_name.name]
  else
    _routes.polymorphic_mappings[record.class.name]
  end
end
```

And finally this is how it looks when I do the same change in the app as monkeypatch

![Screenshot 2023-10-20 at 01 09 13](https://github.com/bobf/active_element/assets/32255826/091abcb3-bc84-4b4a-98cf-ae690940f462)

