### PR TITLE
UI/UX - Updates to checkbox column UI/UX

### DIFF
--- a/app/assets/stylesheets/active_element/application.scss
+++ b/app/assets/stylesheets/active_element/application.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "bootstrap";
 @import "dark";
+@import "checkboxes";
 
 
 @keyframes fade-in {

--- a/app/assets/stylesheets/active_element/checkboxes.scss
+++ b/app/assets/stylesheets/active_element/checkboxes.scss
@@ -1,0 +1,22 @@
+.checkboxes-container{
+  column-width: 300px;
+  .checkbox-wrapper{
+    label{
+      input[type=checkbox]{
+        cursor: pointer;
+      }
+      .label-title{
+        cursor: pointer;
+      }
+
+      input[type=checkbox]:disabled{
+        cursor: not-allowed;
+
+        &+.label-title {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/active_element/checkboxes.scss
+++ b/app/assets/stylesheets/active_element/checkboxes.scss
@@ -1,5 +1,6 @@
 .checkboxes-container{
-  column-width: 300px;
+  column-width: clamp(16rem, 20rem, 22rem);
+
   .checkbox-wrapper{
     label{
       input[type=checkbox]{

--- a/app/views/active_element/components/form/_check_boxes.html.erb
+++ b/app/views/active_element/components/form/_check_boxes.html.erb
@@ -10,23 +10,17 @@
           <br/>
         <% end %>
       <% end %>
-
     </div>
     <hr/>
   <% end %>
 <% else %>
-  <div class="container w-100">
+  <div class="container w-100 checkboxes-container">
     <%= form.fields_for field do |subform| %>
-      <% options.fetch(:options).in_groups(options.fetch(:columns, 1)).reduce(&:zip).each do |columns| %>
-        <div class="row w-100">
-          <% columns.each do |label, name, checked| %>
-            <div class="col">
-              <% if [label, name, checked].any?(&:present?) %>
-                <%= subform.check_box(name, checked: checked, class: 'me-2', tabindex: component.tabindex) %>
-                <%= subform.label name, label %>
-              <% end %>
-            </div>
-            <br/>
+      <% options.fetch(:options).each do |label, name, checked| %>
+        <div class="checkbox-wrapper">
+          <%= subform.label name, label do %>
+            <%= subform.check_box(name, checked: checked, class: '', tabindex: component.tabindex) %>
+            <span class="label-title"><%= label %></span>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Before
- checkboxs are fixed to two columns
- checkbox tab order does not match checkbox order (tabs left to right)
- label looks enabled when checkbox is disabled
- no cursor change on checkbox and label hover

After
- checkbox columns are clamped to 320px wide and extra columns get added as screen size gets wider
- checkbox tab order fixed
- labels are disabled when checkbox is disabled
- cursor changes to pointer on checkbox and label hover
- cursor changes to not allowed on disabled checkbox and label hover