### PR TITLE
Optionally add pagination in footer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_element (0.0.20)
+    active_element (0.0.23)
       bootstrap (~> 5.3.0alpha3)
       kaminari (~> 1.2)
       paintbrush (~> 0.1.2)
@@ -150,7 +150,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.2)
     minitest (5.18.1)
-    net-imap (0.4.11)
+    net-imap (0.4.12)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/views/active_element/components/table/collection.html.erb
+++ b/app/views/active_element/components/table/collection.html.erb
@@ -51,3 +51,10 @@
                          row_class_mapper: row_class_mapper } %>
   <% end %>
 <% end %>
+
+<% if footer_pagination %>
+  <%=
+    render partial: 'active_element/components/table/pagination',
+           locals: { collection: collection, params: params, page_size: page_size, page_sizes: page_sizes }
+  %>
+<% end %>

--- a/lib/active_element/components/collection_table.rb
+++ b/lib/active_element/components/collection_table.rb
@@ -15,7 +15,7 @@ module ActiveElement
       # rubocop:disable Metrics/MethodLength
       def initialize(controller, class_name:, collection:, fields:, params:, model_name: nil, style: nil,
                      show: false, new: false, edit: false, destroy: false, paginate: true, group: nil,
-                     group_title: false, nested_for: nil, row_class: nil, title: nil, **_kwargs)
+                     group_title: false, nested_for: nil, row_class: nil, title: nil, footer_pagination: nil, **_kwargs)
         @controller = controller
         @class_name = class_name
         @model_name = model_name
@@ -34,6 +34,7 @@ module ActiveElement
         @title = title
         @nested_for = nested_for
         verify_paginate_and_group
+        @footer_pagination = footer_pagination
       end
       # rubocop:enable Metrics/MethodLength
 
@@ -60,7 +61,8 @@ module ActiveElement
           page_sizes: [5, 10, 25, 50, 75, 100, 200],
           page_size: page_size,
           i18n: i18n,
-          row_class_mapper: row_class_mapper
+          row_class_mapper: row_class_mapper,
+          footer_pagination: @footer_pagination && display_pagination?
         }
       end
 

--- a/lib/active_element/version.rb
+++ b/lib/active_element/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveElement
-  VERSION = '0.0.20'
+  VERSION = '0.0.23'
 end


### PR DESCRIPTION
Actions:

+ Have an option to render pagination in footer too

Motivations:

+ With default 50 collections per page, it's useful to have pagination both above and under the data