### PR TITLE
Call toast on DOM content load

### DIFF
--- a/app/assets/javascripts/active_element/toast.js
+++ b/app/assets/javascripts/active_element/toast.js
@@ -1,8 +1,10 @@
 (() => {
-  const elements = [].slice.call(document.querySelectorAll('.toast'));
-  const toasts = elements.map(function (element) {
-    return new bootstrap.Toast(element, { animation: true, autohide: true, delay: 10000 })
+  document.addEventListener('DOMContentLoaded', () => {
+    const elements = [].slice.call(document.querySelectorAll('.toast'));
+    const toasts = elements.map(function (element) {
+      return new bootstrap.Toast(element, { animation: true, autohide: true, delay: 10000 })
+    });
+  
+    toasts.forEach((toast) => toast.show());
   });
-
-  toasts.forEach((toast) => toast.show());
 })();


### PR DESCRIPTION
Actions:

+ Call toast only on DOM content load

Motivations:

+ Race condition problem where JS tries to obtain elements with .toast class, but DOM did not load yet and the foo fetches nothing.