### PR TITLE
Fix - Select field in Edit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_element (0.0.27)
+    active_element (0.0.28)
       bootstrap (~> 5.3.0alpha3)
       kaminari (~> 1.2)
       paintbrush (~> 0.1.2)
@@ -150,7 +150,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.2)
     minitest (5.18.1)
-    net-imap (0.4.14)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)

--- a/lib/active_element/components/util/association_mapping.rb
+++ b/lib/active_element/components/util/association_mapping.rb
@@ -23,12 +23,10 @@ module ActiveElement
 
         def relation_id # rubocop:disable Metrics/CyclomaticComplexity
           case relation.macro
-          when :has_one
+          when :has_one, :belongs_to
             associated_record&.public_send(relation_key)
           when :has_many
             associated_record&.map(&relation_key.to_sym)
-          when :belongs_to
-            record&.public_send(relation_key)
           end
         end
 
@@ -37,7 +35,7 @@ module ActiveElement
           when :has_one, :has_many
             relation.klass.primary_key
           when :belongs_to
-            relation.foreign_key
+            relation.association_primary_key
           end
         end
 

--- a/lib/active_element/components/util/form_field_mapping.rb
+++ b/lib/active_element/components/util/form_field_mapping.rb
@@ -170,8 +170,8 @@ module ActiveElement
 
         def relation_select_field(field)
           association = association_mapping(field)
-          columns = [association.display_field, association.associated_model.primary_key].compact
-          [association.relation_key, :select,
+          columns = [association.display_field, association.relation_key].compact
+          [field, :select,
            { multiple: association_mapping(field).multiple_association?,
              options: association.associated_model.pluck(*columns) }]
         end

--- a/lib/active_element/version.rb
+++ b/lib/active_element/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveElement
-  VERSION = '0.0.27'
+  VERSION = '0.0.28'
 end


### PR DESCRIPTION
**Description:**
  Select field in the edit form was not functioning correctly for `belongs_to` association due to a mismatch in association handling.

**Actions:**

-  Updated logic in `association_mapping#relation_key` to return `associated_primary_key` for `belongs_to` association.

-  Replaced the use of `association.associated_model.primary_key` with `association.relation_key` to ensure the correct key is used for associations.